### PR TITLE
Fix typo in cnchi/installation/select_packages.py

### DIFF
--- a/cnchi/installation/select_packages.py
+++ b/cnchi/installation/select_packages.py
@@ -202,7 +202,7 @@ class SelectPackages(object):
 
         if packages_xml_data != None:
             logging.debug("Loading xml data from server...")
-            xml_root = eTree.fromstring(packages_xml)
+            xml_root = eTree.fromstring(packages_xml_data)
         else:
             logging.debug("Loading %s", packages_xml_filename)
             xml_tree = eTree.parse(packages_xml_filename)


### PR DESCRIPTION
"_data" was mising in "package_xml_data" usage and that caused a "variable not declared in this scope" error that freezes install at "getting package list..." While showing a 100% progress.
